### PR TITLE
Fix NaN total points

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -1,6 +1,6 @@
 document.onreadystatechange = function() {
 
-  const getTotalPointsForColumn = column => Array.from(column.querySelectorAll('aui-badge')).reduce((init, current) => init + parseFloat(current.textContent), 0)
+  const getTotalPointsForColumn = column => Array.from(column.querySelectorAll('aui-badge')).reduce((init, current) => init + Number(current.textContent), 0)
 
   const displayTotalPoints = () => {
     const columns = document.querySelectorAll('.ghx-columns .ghx-column')


### PR DESCRIPTION
Fixes [THREESCALE-2058: Update jira-board-total-points plugin](https://issues.jboss.org/browse/THREESCALE-2058)

Uses `Number` instead of `parseFloat`.